### PR TITLE
Document Gotify notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ docker run -it --rm \
 - `mail-only-on-error` - only send a mail if the execution was not successful.
 - `insecure-skip-verify` - ignore certificate checks on SMTP host. (+1.0.2 only!)
 
+- `gotify-webhook` - URL of the gotify webhook. (format: `https://GOTIFY_URL/message?token=TOKEN`)
+- `gotify-only-on-erroy` - only send a gotify message if the execution was not succesful.
+- `gotify-priority` - priority of the gotify message
+
 - `save-folder` - directory in which the reports shall be written.
 - `save-only-on-error` - only save a report if the execution was not successful.
 


### PR DESCRIPTION
I can confirm Gotify works great for me :)

While the exact URL is documented on https://gotify.net/docs/pushmsg, it's not given when you add a new app to Gotify (just the token is), so I figured I'd document the exact URL format in the README too.