### PR TITLE
Removed reference to deprecated `--docker` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ services:
     image: premoweb/chadburn:latest
     depends_on:
       - nginx
-    command: daemon --docker
+    command: daemon
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 


### PR DESCRIPTION
Simple readme update to avoid confusion w/ deprecated flag - ran into this while upgrading my deployment from the ofelia image. 