### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run -it --rm \
         premoweb/chadburn:latest daemon
 ```
 
-Labels format: `chadburn.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>.
+Labels format: `chadburn.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>`.
 This type of configuration supports all the capabilities provided by INI files.
 
 Also, it is possible to configure `job-exec` by setting labels configurations on the target container. To do that, additional label `chadburn.enabled=true` need to be present on the target container.


### PR DESCRIPTION
The was a missing ` in the *README.md* file