### PR TITLE
prevent deletion of jobs added through config file

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -119,6 +119,11 @@ func (c *Config) dockerLabelsUpdate(labels map[string]map[string]string) {
 
 	// Calculate the delta
 	for name, j := range c.ExecJobs {
+		// this prevents deletion of jobs that were added by reading a configuration file
+		if !j.FromDockerLabel {
+			continue
+		}
+
 		found := false
 		for newJobsName, newJob := range parsedLabelConfig.ExecJobs {
 			// Check if the schedule has changed
@@ -178,6 +183,7 @@ type ExecJobConfig struct {
 	middlewares.SaveConfig    `mapstructure:",squash"`
 	middlewares.MailConfig    `mapstructure:",squash"`
 	middlewares.GotifyConfig  `mapstructure:",squash"`
+	FromDockerLabel bool `mapstructure:"fromDockerLabel"`
 }
 
 func (c *ExecJobConfig) buildMiddlewares() {

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -47,6 +47,7 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 			case jobType == jobExec: // only job exec can be provided on the non-service container
 				if _, ok := execJobs[jobName]; !ok {
 					execJobs[jobName] = make(map[string]interface{})
+					execJobs[jobName]["fromDockerLabel"] = true
 				}
 
 				setJobParam(execJobs[jobName], jopParam, v)


### PR DESCRIPTION
This solves #28 

Local test with config file and container with labels:
```
scheduler.go:89 ▶ NOTICE New job registered "autoprint-fax" - "touch /tmp/example" - "@every 2m" - ID: 1
scheduler.go:101 ▶ DEBUG Starting scheduler
cron_utils.go:13 ▶ DEBUG start
cron_utils.go:13 ▶ DEBUG schedule
scheduler.go:89 ▶ NOTICE New job registered "test-exec-job" - "uname -a" - "@every 5s" - ID: 2
cron_utils.go:13 ▶ DEBUG added
cron_utils.go:13 ▶ DEBUG wake
cron_utils.go:13 ▶ DEBUG run
common.go:127 ▶ NOTICE [Job "test-exec-job" (1ecc7b7c2806)] Started - uname -a
common.go:127 ▶ NOTICE [Job "test-exec-job" (1ecc7b7c2806)] Output: Linux b4a818a67521 5.10.103-5.ph4-esx #1-photon SMP Sun May 1 05:01:24 UTC 2022 x86_64 GNU/Linux
common.go:127 ▶ NOTICE [Job "test-exec-job" (1ecc7b7c2806)] Finished in "56.294059ms", failed: false, skipped: false, error: none
cron_utils.go:13 ▶ DEBUG wake
cron_utils.go:13 ▶ DEBUG run
common.go:127 ▶ NOTICE [Job "test-exec-job" (09a25b986db2)] Started - uname -a
common.go:127 ▶ NOTICE [Job "test-exec-job" (09a25b986db2)] Output: Linux b4a818a67521 5.10.103-5.ph4-esx #1-photon SMP Sun May 1 05:01:24 UTC 2022 x86_64 GNU/Linux
common.go:127 ▶ NOTICE [Job "test-exec-job" (09a25b986db2)] Finished in "49.752522ms", failed: false, skipped: false, error: none
cron_utils.go:13 ▶ DEBUG wake
cron_utils.go:13 ▶ DEBUG run
common.go:127 ▶ NOTICE [Job "test-exec-job" (e36f4735d8cb)] Started - uname -a
common.go:127 ▶ NOTICE [Job "test-exec-job" (e36f4735d8cb)] Output: Linux b4a818a67521 5.10.103-5.ph4-esx #1-photon SMP Sun May 1 05:01:24 UTC 2022 x86_64 GNU/Linux
common.go:127 ▶ NOTICE [Job "test-exec-job" (e36f4735d8cb)] Finished in "49.346655ms", failed: false, skipped: false, error: none
cron_utils.go:13 ▶ DEBUG wake
cron_utils.go:13 ▶ DEBUG run
common.go:127 ▶ NOTICE [Job "test-exec-job" (ac3e5aaea306)] Started - uname -a
common.go:123 ▶ ERROR [Job "test-exec-job" (ac3e5aaea306)] Finished in "920.935µs", failed: true, skipped: false, error: error creating exec: No such container: heuristic_heyrovsky
scheduler.go:94 ▶ NOTICE Job deregistered (will not fire again) "test-exec-job" - "uname -a" - "@every 5s" - ID: 2
cron_utils.go:13 ▶ DEBUG removed
cron_utils.go:13 ▶ DEBUG wake
cron_utils.go:13 ▶ DEBUG run
common.go:127 ▶ NOTICE [Job "autoprint-fax" (0edb5fa1913c)] Started - touch /tmp/example
common.go:127 ▶ NOTICE [Job "autoprint-fax" (0edb5fa1913c)] Finished in "53.31728ms", failed: false, skipped: false, error: none
```

The config file now gets loaded correctly and any containers with labels get loaded and unloaded correctly.