### PR TITLE
Make job-local work with docker labels

### DIFF
--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -59,6 +59,7 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 			case jobType == jobLocal && isServiceContainer:
 				if _, ok := localJobs[jobName]; !ok {
 					localJobs[jobName] = make(map[string]interface{})
+					localJobs[jobName]["fromDockerLabel"] = true
 				}
 				setJobParam(localJobs[jobName], jopParam, v)
 			case jobType == jobServiceRun && isServiceContainer:

--- a/core/localjob.go
+++ b/core/localjob.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"os/exec"
+	"reflect"
 
 	"github.com/gobs/args"
 )
@@ -14,6 +15,13 @@ type LocalJob struct {
 
 func NewLocalJob() *LocalJob {
 	return &LocalJob{}
+}
+
+// Returns a hash of all the job attributes. Used to detect changes
+func (j *LocalJob) Hash() string {
+	var hash string
+	getHash(reflect.TypeOf(j).Elem(), reflect.ValueOf(j).Elem(), &hash)
+	return hash
 }
 
 func (j *LocalJob) Run(ctx *Context) error {


### PR DESCRIPTION
`job-local` jobs did not work before this pull request, because only `job-exec` ones are honored from the docker labels.

I'm not very happy with the copy-paste of code I did in this PR, but since the repo uses an old version of go it's not easy to use generics, and updating to 1.18 seems to cause many dependency issues.