### PR TITLE
Allow specify log level through env var

### DIFF
--- a/chadburn.go
+++ b/chadburn.go
@@ -20,6 +20,20 @@ func buildLogger() core.Logger {
 	// Set the backends to be used.
 	logging.SetBackend(stdout)
 	logging.SetFormatter(logging.MustStringFormatter(logFormat))
+
+	// set default level
+	logging.SetLevel(logging.INFO, "chadburn")
+
+	level_string, got_env_var := os.LookupEnv("CHADBURN_LOG_LEVEL")
+	if got_env_var {
+		level, err := logging.LogLevel(level_string)
+		if err == nil {
+			logging.SetLevel(level, "chadburn")
+		} else {
+			fmt.Println("WARNING: could not interpret", level_string, "as log level: ", err)
+		}
+	}
+
 	return logging.MustGetLogger("chadburn")
 }
 


### PR DESCRIPTION
I found the default log level very verbose (was 'debug'). Now it defaults to 'info', and one can use CHADBURN_LOG_LEVEL to change it if needed