### PR TITLE
Fix Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/PremoWeb/Chadburn
 
-go 1.23.0
+go 1.19
 
-toolchain go1.23.7
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
This PR updates the Go version in go.mod to 1.19 and removes the toolchain directive to fix the failing tests.