### PR TITLE
Fix Dockerfile to use Go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-alpine AS builder
+FROM golang:1.19-alpine AS builder
 
 LABEL org.opencontainers.image.description="Cron alternative for Docker Swarm enviornments."
 


### PR DESCRIPTION
This PR updates the Dockerfile to use Go 1.19 instead of Go 1.23.2 to match the go.mod file.