### PR TITLE
Fix GitHub Actions workflow to use Go 1.23

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Go 1.23 instead of Go 1.19 to match the go.mod file. This should resolve the failing tests and linting issues.