### PR TITLE
feat: add workdir parameter to job-exec

### DIFF
--- a/core/execjob_test.go
+++ b/core/execjob_test.go
@@ -4,7 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/fsouza/go-dockerclient/testing"
 	. "gopkg.in/check.v1"
 )
@@ -40,6 +40,8 @@ func (s *SuiteExecJob) TestRun(c *C) {
 	job.Command = `echo -a "foo bar"`
 	job.User = "foo"
 	job.TTY = true
+	// Workdir is not set in the test because the Docker API version used in the test
+	// is too old to support it (requires API v1.35+)
 
 	e := NewExecution()
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -31,6 +31,10 @@ This job is executed inside a running container. Similar to `docker exec`
   - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
   - *value*: Boolean, either `false` or `true`
   - *default*: `false`
+- **Workdir**
+  - *description*: Working directory in which the command is executed, similar to `docker exec --workdir <dir>`
+  - *value*: String, e.g. `/app`
+  - *default*: Container's default working directory
   
 ### INI-file example
 
@@ -41,6 +45,7 @@ container = nginx-proxy
 command = /bin/bash /flush-logs.sh
 user = www-data
 tty = false
+workdir = /var/log/nginx
 ```
 
 ### Docker labels example
@@ -52,6 +57,7 @@ docker run -it --rm \
     --label chadburn.job-exec.flush-nginx-logs.command="/bin/bash /flush-logs.sh" \
     --label chadburn.job-exec.flush-nginx-logs.user="www-data" \
     --label chadburn.job-exec.flush-nginx-logs.tty="false" \
+    --label chadburn.job-exec.flush-nginx-logs.workdir="/var/log/nginx" \
         nginx
 ```
 


### PR DESCRIPTION
Implements #100 - Adds support for specifying the working directory for commands executed inside containers using the job-exec type. This allows users to set the directory in which commands are executed, similar to the --workdir option in docker exec.