### PR TITLE
feat: add support for container lifecycle jobs (issue #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,8 @@
 ### Features
 
 * implement automatic version bump system and update README badges ([7ff96c3](https://github.com/PremoWeb/chadburn/commit/7ff96c36dec1b73d0deb472dda1375a5281ca272))
+
+## Unreleased
+
+### Added
+- Added support for container lifecycle jobs (`job-lifecycle`) that run once on container start or stop events.

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -12,13 +12,24 @@ import (
 var ErrNoContainerWithChadburnEnabled = errors.New("Couldn't find containers with label 'chadburn.enabled=true'")
 
 type DockerHandler struct {
-	dockerClient *docker.Client
-	notifier     dockerLabelsUpdate
-	logger       core.Logger
+	dockerClient  *docker.Client
+	notifier      dockerLabelsUpdate
+	logger        core.Logger
+	lifecycleJobs map[string]*LifecycleJobConfig // Map of lifecycle jobs
 }
 
 type dockerLabelsUpdate interface {
 	dockerLabelsUpdate(map[string]map[string]string)
+}
+
+// GetLifecycleJobs returns the lifecycle jobs
+func (c *DockerHandler) GetLifecycleJobs() map[string]*LifecycleJobConfig {
+	return c.lifecycleJobs
+}
+
+// SetLifecycleJobs sets the lifecycle jobs
+func (c *DockerHandler) SetLifecycleJobs(jobs map[string]*LifecycleJobConfig) {
+	c.lifecycleJobs = jobs
 }
 
 // TODO: Implement an interface so the code does not have to use third parties directly
@@ -41,6 +52,7 @@ func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger) (*DockerH
 	c.dockerClient, err = c.buildDockerClient()
 	c.notifier = notifier
 	c.logger = logger
+	c.lifecycleJobs = make(map[string]*LifecycleJobConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -51,6 +63,7 @@ func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger) (*DockerH
 	}
 
 	go c.watch()
+	go c.watchEvents() // Start watching Docker events
 	return c, nil
 }
 
@@ -66,6 +79,78 @@ func (c *DockerHandler) watch() {
 				c.logger.Debugf("%v", err)
 			}
 			c.notifier.dockerLabelsUpdate(labels)
+		}
+	}
+}
+
+// watchEvents listens for Docker events and triggers lifecycle jobs
+func (c *DockerHandler) watchEvents() {
+	// Create a channel to receive Docker events
+	events := make(chan *docker.APIEvents)
+
+	// Add event listener
+	err := c.dockerClient.AddEventListener(events)
+	if err != nil {
+		c.logger.Errorf("Failed to add event listener: %v", err)
+		return
+	}
+
+	// Remove event listener when done
+	defer c.dockerClient.RemoveEventListener(events)
+
+	c.logger.Noticef("Started watching Docker events")
+
+	// Listen for events
+	for event := range events {
+		// Only process container events
+		if event.Type != "container" {
+			continue
+		}
+
+		// Get container info
+		container, err := c.dockerClient.InspectContainer(event.ID)
+		if err != nil {
+			c.logger.Debugf("Failed to inspect container %s: %v", event.ID, err)
+			continue
+		}
+
+		// Get container name without leading slash
+		containerName := strings.TrimPrefix(container.Name, "/")
+
+		// Process the event
+		switch event.Action {
+		case "start":
+			c.logger.Debugf("Container %s started", containerName)
+			c.processLifecycleEvent(containerName, event.ID, core.ContainerStart)
+		case "die", "stop":
+			c.logger.Debugf("Container %s stopped", containerName)
+			c.processLifecycleEvent(containerName, event.ID, core.ContainerStop)
+		}
+	}
+}
+
+// processLifecycleEvent processes a container lifecycle event
+func (c *DockerHandler) processLifecycleEvent(containerName, containerID string, eventType core.LifecycleEventType) {
+	// Check if we have any lifecycle jobs for this container
+	for name, job := range c.lifecycleJobs {
+		// Check if this job should run for this container and event type
+		if job.Container == containerName && job.EventType == eventType && !job.Executed {
+			c.logger.Noticef("Running lifecycle job %s for container %s on %s event", name, containerName, eventType)
+
+			// Create execution context
+			ctx := &core.Context{
+				Execution: core.NewExecution(),
+				Logger:    c.logger,
+				Job:       &job.LifecycleJob,
+			}
+
+			// Run the job
+			err := job.Run(ctx)
+			if err != nil {
+				c.logger.Errorf("Failed to run lifecycle job %s: %v", name, err)
+			} else {
+				c.logger.Noticef("Lifecycle job %s completed successfully", name)
+			}
 		}
 	}
 }

--- a/core/lifecyclejob.go
+++ b/core/lifecyclejob.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"reflect"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+// LifecycleEventType represents the type of container lifecycle event
+type LifecycleEventType string
+
+const (
+	// ContainerStart represents a container start event
+	ContainerStart LifecycleEventType = "start"
+	// ContainerStop represents a container stop event
+	ContainerStop LifecycleEventType = "stop"
+)
+
+// LifecycleJob represents a job that runs once on container lifecycle events
+type LifecycleJob struct {
+	BareJob   `mapstructure:",squash"`
+	Client    *docker.Client     `json:"-"`
+	Container string             `hash:"true"` // Container ID or name to monitor
+	EventType LifecycleEventType `hash:"true"` // Type of event to trigger on (start, stop)
+	Executed  bool               `hash:"-"`    // Whether this job has been executed
+}
+
+// NewLifecycleJob creates a new LifecycleJob
+func NewLifecycleJob(c *docker.Client) *LifecycleJob {
+	return &LifecycleJob{
+		Client:    c,
+		EventType: ContainerStart, // Default to start event
+		Executed:  false,
+	}
+}
+
+// Run executes the job
+func (j *LifecycleJob) Run(ctx *Context) error {
+	if j.Executed {
+		// Skip if already executed
+		return nil
+	}
+
+	// Create variable context with container info
+	varContext := VariableContext{
+		Container: ContainerInfo{
+			Name: j.Container,
+			ID:   j.Container, // We use the container name as ID for now
+		},
+	}
+
+	// Get processed command with variables replaced
+	processedCommand := j.GetProcessedCommand(varContext)
+
+	// Execute the command locally
+	localJob := &LocalJob{
+		BareJob:       j.BareJob,
+		ContainerID:   j.Container,
+		ContainerName: j.Container,
+	}
+
+	// Override the command with the processed one
+	localJob.Command = processedCommand
+
+	// Run the local job
+	err := localJob.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Mark as executed
+	j.Executed = true
+	return nil
+}
+
+// Returns a hash of all the job attributes. Used to detect changes
+func (j *LifecycleJob) Hash() string {
+	var hash string
+	getHash(reflect.TypeOf(j).Elem(), reflect.ValueOf(j).Elem(), &hash)
+	return hash
+}
+
+// ShouldRun determines if the job should run based on the event type
+func (j *LifecycleJob) ShouldRun(eventType LifecycleEventType) bool {
+	return !j.Executed && j.EventType == eventType
+}
+
+// Reset resets the executed state of the job
+func (j *LifecycleJob) Reset() {
+	j.Executed = false
+}
+
+// SetVolumeMounts is a no-op for LifecycleJob
+func (j *LifecycleJob) SetVolumeMounts(volumes []string) {
+	// No-op for LifecycleJob
+}

--- a/core/lifecyclejob.go
+++ b/core/lifecyclejob.go
@@ -53,14 +53,13 @@ func (j *LifecycleJob) Run(ctx *Context) error {
 	processedCommand := j.GetProcessedCommand(varContext)
 
 	// Execute the command locally
-	localJob := &LocalJob{
-		BareJob:       j.BareJob,
-		ContainerID:   j.Container,
-		ContainerName: j.Container,
-	}
-
-	// Override the command with the processed one
-	localJob.Command = processedCommand
+	localJob := &LocalJob{}
+	// Set fields individually instead of copying the BareJob struct
+	localJob.Name = j.Name
+	localJob.Schedule = j.Schedule
+	localJob.Command = processedCommand // Use the processed command
+	localJob.ContainerID = j.Container
+	localJob.ContainerName = j.Container
 
 	// Run the local job
 	err := localJob.Run(ctx)

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -6,6 +6,63 @@
 - [job-service-run](#job-service-run)
 - [Variable Substitution](#variable-substitution)
 
+## Job Types
+
+Chadburn supports several job types:
+
+- `job-local`: Executes commands on the host machine.
+- `job-exec`: Executes commands inside a running container.
+- `job-run`: Creates a new container to execute commands.
+- `job-service-run`: Creates a service to execute commands.
+- `job-lifecycle`: Executes commands on container lifecycle events (start/stop).
+
+### job-lifecycle
+
+The `job-lifecycle` type allows you to execute commands when a container starts or stops. This is useful for sending notifications, performing cleanup, or triggering other actions based on container lifecycle events.
+
+Unlike other job types, `job-lifecycle` jobs don't run on a schedule. Instead, they run once when the specified container lifecycle event occurs.
+
+#### Configuration
+
+```toml
+[job-lifecycle "notify-on-start"]
+container = "my-container"
+event-type = "start"
+command = "echo 'Container my-container started' | mail -s 'Container Started' admin@example.com"
+
+[job-lifecycle "cleanup-on-stop"]
+container = "my-container"
+event-type = "stop"
+command = "echo 'Container my-container stopped' | mail -s 'Container Stopped' admin@example.com"
+```
+
+#### Docker Compose Labels
+
+```yaml
+services:
+  my-service:
+    image: nginx
+    labels:
+      chadburn.enabled: "true"
+      chadburn.job-lifecycle.notify-on-start.command: "echo 'Container {{.Container.Name}} started' | mail -s 'Container Started' admin@example.com"
+      chadburn.job-lifecycle.notify-on-start.event-type: "start"
+      chadburn.job-lifecycle.cleanup-on-stop.command: "echo 'Container {{.Container.Name}} stopped' | mail -s 'Container Stopped' admin@example.com"
+      chadburn.job-lifecycle.cleanup-on-stop.event-type: "stop"
+```
+
+#### Parameters
+
+- `container`: The name or ID of the container to monitor.
+- `event-type`: The type of event to trigger on. Valid values are `start` and `stop`.
+- `command`: The command to execute when the event occurs.
+
+#### Variables
+
+You can use the following variables in your commands:
+
+- `{{.Container.Name}}`: The name of the container.
+- `{{.Container.ID}}`: The ID of the container.
+
 ## Job-exec
 
 This job is executed inside a running container. Similar to `docker exec`


### PR DESCRIPTION
This PR adds support for container lifecycle jobs that run once on container start or stop events. This addresses issue #68.