### PR TITLE
Fix Cloudflare Pages deployment issues

### DIFF
--- a/docs-svelte/src/routes/(docs)/[...slug]/+page.server.ts
+++ b/docs-svelte/src/routes/(docs)/[...slug]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-// Use a simpler approach with virtual modules
-const markdownModules = import.meta.glob('/static/markdown/**/*.md', { as: 'raw', eager: true });
+// Use the recommended approach with query parameter instead of deprecated 'as' option
+const markdownModules = import.meta.glob('/static/markdown/**/*.md', { query: '?raw', import: 'default', eager: true });
 
 export const load: PageServerLoad = async ({ params, url }) => {
 	try {

--- a/docs-svelte/static/data/contributors.json
+++ b/docs-svelte/static/data/contributors.json
@@ -69,7 +69,7 @@
     "type": "User",
     "user_view_type": "public",
     "site_admin": false,
-    "contributions": 13
+    "contributions": 14
   },
   {
     "login": "jinnatar",

--- a/docs-svelte/wrangler.toml
+++ b/docs-svelte/wrangler.toml
@@ -1,1 +1,1 @@
-compatibility_flags = ["nodejs_compat"] 
+compatibility_flags = ["nodejs_compat"]

--- a/docs-svelte/wrangler.toml
+++ b/docs-svelte/wrangler.toml
@@ -1,2 +1,1 @@
-[compatibility_flags]
-nodejs_compat = true 
+compatibility_flags = ["nodejs_compat"] 


### PR DESCRIPTION
This PR fixes two issues with the Cloudflare Pages deployment: 1. Updates the wrangler.toml file to use the correct format for compatibility_flags (array of strings instead of object) 2. Updates the deprecated import.meta.glob syntax in +page.server.ts to use the recommended query parameter format. These changes resolve the deployment failures that were occurring with the documentation site.