### PR TITLE
Add warning banner and make header sticky

### DIFF
--- a/docs-svelte/src/lib/components/WarningBanner.svelte
+++ b/docs-svelte/src/lib/components/WarningBanner.svelte
@@ -14,7 +14,7 @@
         <strong>Development Notice:</strong> Chadburn is undergoing a major rewrite. The code is not fully tested and documentation may not reflect current functionality. Please use prior stable versions for production environments.
       </p>
       <p class="donation-text">
-        <strong>Support Needed:</strong> Development costs are mounting. Please consider donating via PayPal or Venmo to <strong>nick@premoweb.com</strong> to help fund AI tools and development time.
+        <strong>Urgent Support Needed:</strong> Over $60 has been spent this month alone on development and domain costs, paid out-of-pocket by the financially strained lead developer. Please help cover these expenses via PayPal or Venmo to <strong>nick@premoweb.com</strong> to ensure continued development toward a stable release with new features. Feel free to reach out to discuss features you'd like to see.
       </p>
     </div>
   </div>

--- a/docs-svelte/src/lib/components/WarningBanner.svelte
+++ b/docs-svelte/src/lib/components/WarningBanner.svelte
@@ -9,9 +9,14 @@
       <line x1="12" y1="9" x2="12" y2="13"></line>
       <line x1="12" y1="17" x2="12.01" y2="17"></line>
     </svg>
-    <p>
-      <strong>Development Notice:</strong> Chadburn is undergoing a major rewrite. The code is not fully tested and documentation may not reflect current functionality. Please use prior stable versions for production environments.
-    </p>
+    <div class="message-container">
+      <p>
+        <strong>Development Notice:</strong> Chadburn is undergoing a major rewrite. The code is not fully tested and documentation may not reflect current functionality. Please use prior stable versions for production environments.
+      </p>
+      <p class="donation-text">
+        <strong>Support Needed:</strong> Development costs are mounting. Please consider donating via PayPal or Venmo to <strong>nick@premoweb.com</strong> to help fund AI tools and development time.
+      </p>
+    </div>
   </div>
 </div>
 
@@ -30,7 +35,7 @@
     margin: 0 auto;
     padding: 0.75rem 1rem;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.75rem;
   }
 
@@ -38,6 +43,11 @@
     flex-shrink: 0;
     width: 24px;
     height: 24px;
+    margin-top: 3px;
+  }
+
+  .message-container {
+    flex: 1;
   }
 
   p {
@@ -46,11 +56,21 @@
     line-height: 1.4;
   }
 
+  .donation-text {
+    margin-top: 0.5rem;
+    font-size: 0.95rem;
+    color: #721c24;
+  }
+
   @media (max-width: 768px) {
     .warning-content {
       flex-direction: column;
       text-align: center;
       padding: 1rem;
+    }
+    
+    .donation-text {
+      margin-top: 0.75rem;
     }
   }
 </style> 

--- a/docs-svelte/src/lib/components/WarningBanner.svelte
+++ b/docs-svelte/src/lib/components/WarningBanner.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  // No props or state needed for this simple banner
+</script>
+
+<div class="warning-banner">
+  <div class="warning-content">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="warning-icon">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+      <line x1="12" y1="9" x2="12" y2="13"></line>
+      <line x1="12" y1="17" x2="12.01" y2="17"></line>
+    </svg>
+    <p>
+      <strong>Development Notice:</strong> Chadburn is undergoing a major rewrite. The code is not fully tested and documentation may not reflect current functionality. Please use prior stable versions for production environments.
+    </p>
+  </div>
+</div>
+
+<style>
+  .warning-banner {
+    background-color: #fff3cd;
+    border: 1px solid #ffeeba;
+    color: #856404;
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 1rem;
+  }
+
+  .warning-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .warning-icon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  @media (max-width: 768px) {
+    .warning-content {
+      flex-direction: column;
+      text-align: center;
+      padding: 1rem;
+    }
+  }
+</style> 

--- a/docs-svelte/src/routes/(docs)/+layout.svelte
+++ b/docs-svelte/src/routes/(docs)/+layout.svelte
@@ -6,6 +6,7 @@
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import ScrollToTop from '$lib/components/ScrollToTop.svelte';
+	import WarningBanner from '$lib/components/WarningBanner.svelte';
 	
 	let { children } = $props();
 	
@@ -32,6 +33,7 @@
 	<div class="content-wrapper">
 		<Sidebar />
 		<main class="main-content">
+			<WarningBanner />
 			<div class="page-transition-container">
 				{@render children()}
 			</div>

--- a/docs-svelte/src/routes/(docs)/+layout.svelte
+++ b/docs-svelte/src/routes/(docs)/+layout.svelte
@@ -6,7 +6,6 @@
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import ScrollToTop from '$lib/components/ScrollToTop.svelte';
-	import WarningBanner from '$lib/components/WarningBanner.svelte';
 	
 	let { children } = $props();
 	
@@ -33,7 +32,6 @@
 	<div class="content-wrapper">
 		<Sidebar />
 		<main class="main-content">
-			<WarningBanner />
 			<div class="page-transition-container">
 				{@render children()}
 			</div>

--- a/docs-svelte/src/routes/(docs)/[...slug]/+page.server.ts
+++ b/docs-svelte/src/routes/(docs)/[...slug]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-// Use a simpler approach with virtual modules
-const markdownModules = import.meta.glob('/static/markdown/**/*.md', { as: 'raw', eager: true });
+// Use the recommended approach with query parameter instead of deprecated 'as' option
+const markdownModules = import.meta.glob('/static/markdown/**/*.md', { query: '?raw', import: 'default', eager: true });
 
 export const load: PageServerLoad = async ({ params, url }) => {
 	try {

--- a/docs-svelte/src/routes/+layout.svelte
+++ b/docs-svelte/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import { base } from '$app/paths';
 	import ParentNav from '$lib/components/ParentNav.svelte';
 	import { version } from '$lib/stores/version';
+	import WarningBanner from '$lib/components/WarningBanner.svelte';
 	import '../app.css';
 </script>
 
@@ -19,6 +20,8 @@
 			<ParentNav />
 		</div>
 	</header>
+
+	<WarningBanner />
 
 	<main>
 		<div class="content">

--- a/docs-svelte/src/routes/+layout.svelte
+++ b/docs-svelte/src/routes/+layout.svelte
@@ -66,6 +66,10 @@
 		color: white;
 		padding: 1rem 0;
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+		position: sticky;
+		top: 0;
+		z-index: 1000;
+		width: 100%;
 	}
 
 	.header-content {

--- a/docs-svelte/src/routes/+layout.svelte
+++ b/docs-svelte/src/routes/+layout.svelte
@@ -2,7 +2,6 @@
 	import { base } from '$app/paths';
 	import ParentNav from '$lib/components/ParentNav.svelte';
 	import { version } from '$lib/stores/version';
-	import WarningBanner from '$lib/components/WarningBanner.svelte';
 	import '../app.css';
 </script>
 
@@ -20,8 +19,6 @@
 			<ParentNav />
 		</div>
 	</header>
-
-	<WarningBanner />
 
 	<main>
 		<div class="content">

--- a/docs-svelte/static/data/contributors.json
+++ b/docs-svelte/static/data/contributors.json
@@ -69,7 +69,7 @@
     "type": "User",
     "user_view_type": "public",
     "site_admin": false,
-    "contributions": 13
+    "contributions": 14
   },
   {
     "login": "jinnatar",

--- a/docs-svelte/wrangler.toml
+++ b/docs-svelte/wrangler.toml
@@ -1,1 +1,1 @@
-compatibility_flags = ["nodejs_compat"] 
+compatibility_flags = ["nodejs_compat"]

--- a/docs-svelte/wrangler.toml
+++ b/docs-svelte/wrangler.toml
@@ -1,2 +1,1 @@
-[compatibility_flags]
-nodejs_compat = true 
+compatibility_flags = ["nodejs_compat"] 


### PR DESCRIPTION
This PR adds a warning banner to notify users about the project status and financial needs. It also makes the header sticky for better navigation experience.