### PR TITLE
Fix Docker socket permissions documentation (Issue #116)

### DIFF
--- a/docs-svelte/static/markdown/installation.md
+++ b/docs-svelte/static/markdown/installation.md
@@ -53,6 +53,57 @@ Save this to a file named `docker-compose.yml` and run:
 docker-compose up -d
 ```
 
+## Docker Socket Permissions
+
+> **Important Note**: Recent versions of Chadburn have migrated from the `fsouza/go-dockerclient` library to the official Docker client library. This change may require additional configuration for Docker socket permissions.
+
+If you encounter permission errors like:
+
+```
+Docker events error: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
+```
+
+You have several options:
+
+### Option 1: Use SELinux Volume Labels (Recommended for SELinux Systems)
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock:ro,z
+```
+
+### Option 2: Match the Docker Group ID
+
+```yaml
+services:
+  chadburn:
+    # ... other configuration
+    user: "${UID:-1000}:${DOCKER_GID:-999}"
+    environment:
+      - DOCKER_GID=${DOCKER_GID:-999}
+```
+
+When starting the container:
+
+```bash
+# Get the Docker GID
+DOCKER_GID=$(getent group docker | cut -d: -f3)
+
+# Start with the correct GID
+DOCKER_GID=$DOCKER_GID docker-compose up -d
+```
+
+### Option 3: Run as Root (Less Secure)
+
+```yaml
+services:
+  chadburn:
+    # ... other configuration
+    user: "root"
+```
+
+For more detailed information on Docker socket permissions, see the [Docker Socket Permissions Guide](docker-socket-permissions.md).
+
 ## Configuration
 
 After installation, you'll need to create a configuration file. Create a file named `config.yml` with the following basic structure:

--- a/docs-svelte/static/markdown/troubleshooting.md
+++ b/docs-svelte/static/markdown/troubleshooting.md
@@ -12,12 +12,20 @@ This guide provides solutions for common issues you might encounter when using C
 ERROR Docker events error: permission denied while trying to connect to the Docker daemon socket
 ```
 
-**Solution**: This is a common issue related to Docker socket permissions. See the [Docker Socket Permissions Guide](docker-socket-permissions.md) for detailed solutions.
+**Solution**: This issue is related to Docker socket permissions, which may be more prominent in recent versions due to the migration to the official Docker client library.
+
+See the [Docker Socket Permissions Guide](docker-socket-permissions.md) for detailed solutions.
 
 Quick fixes:
 1. Add the `:z` suffix to the volume mount: `-v /var/run/docker.sock:/var/run/docker.sock:ro,z`
-2. Run the container with the correct Docker group ID: `-e DOCKER_GID=$(getent group docker | cut -d: -f3)`
+2. Run the container with the correct Docker group ID: 
+   ```bash
+   DOCKER_GID=$(getent group docker | cut -d: -f3)
+   docker run -e DOCKER_GID=$DOCKER_GID --user "1000:$DOCKER_GID" ...
+   ```
 3. Run the container as root: `--user root`
+
+**Note for upgraders**: If you're upgrading from an older version of Chadburn and suddenly experiencing this issue, it's likely due to the migration from `fsouza/go-dockerclient` to the official Docker client library. The official client may have different permission requirements.
 
 ### Jobs Not Running
 


### PR DESCRIPTION
This PR improves the documentation for Docker socket permissions to address issue #116. It explains the recent migration from fsouza/go-dockerclient to the official Docker client library and provides updated guidance on how to handle permission issues.