### PR TITLE
Fix Docker socket connection issues (Issue #117)

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -192,6 +192,13 @@ func (c *Config) buildSchedulerMiddlewares(sh *core.Scheduler) {
 }
 
 func (c *Config) dockerLabelsUpdate(labels map[string]map[string]string) {
+	// If labels is nil or empty, this might be due to a connection issue
+	// Don't de-register jobs in this case to prevent thrashing
+	if labels == nil || len(labels) == 0 {
+		c.logger.Debugf("No labels received, skipping update to prevent job de-registration")
+		return
+	}
+
 	// Get the current labels
 	var parsedLabelConfig Config
 	parsedLabelConfig.buildFromDockerLabels(labels)


### PR DESCRIPTION
This PR addresses issue #117 by implementing several improvements to handle Docker socket connection issues more gracefully: 1. Added exponential backoff for Docker daemon connection errors in both Docker handlers (not just EOF errors) 2. Prevented job de-registration when no labels are received due to connection issues 3. Improved error handling and logging for connection problems. These changes should prevent the rapid reconnection attempts, excessive CPU usage, and job de-registration loops that were occurring when there were intermittent Docker socket connection issues.