### PR TITLE
Add multi-platform binary builds and enhance asset display

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -78,7 +78,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.prep.outputs.tags }}
 
@@ -88,18 +88,68 @@ jobs:
         with:
           go-version: 1.19
 
-      # Step 10: Build Go binary for linux/amd64 (add more builds if needed)
-      - name: Build Go Binary for linux/amd64
+      # Step 10: Build Go binaries for multiple platforms
+      - name: Build Go Binaries
+        id: build_binaries
         run: |
-          GOOS=linux GOARCH=amd64 go build -o chadburn-linux-amd64
+          # Create a directory for binaries
+          mkdir -p ./dist
+          
+          # Build for Linux (amd64, arm64, arm)
+          GOOS=linux GOARCH=amd64 go build -o ./dist/chadburn-linux-amd64
+          GOOS=linux GOARCH=arm64 go build -o ./dist/chadburn-linux-arm64
+          GOOS=linux GOARCH=arm GOARM=7 go build -o ./dist/chadburn-linux-armv7
+          
+          # Build for macOS (amd64, arm64)
+          GOOS=darwin GOARCH=amd64 go build -o ./dist/chadburn-darwin-amd64
+          GOOS=darwin GOARCH=arm64 go build -o ./dist/chadburn-darwin-arm64
+          
+          # Build for Windows (amd64, arm64)
+          GOOS=windows GOARCH=amd64 go build -o ./dist/chadburn-windows-amd64.exe
+          GOOS=windows GOARCH=arm64 go build -o ./dist/chadburn-windows-arm64.exe
+          
+          # Create archives for each binary
+          cd ./dist
+          
+          # Linux archives
+          tar -czf chadburn-linux-amd64.tar.gz chadburn-linux-amd64
+          tar -czf chadburn-linux-arm64.tar.gz chadburn-linux-arm64
+          tar -czf chadburn-linux-armv7.tar.gz chadburn-linux-armv7
+          
+          # macOS archives
+          tar -czf chadburn-darwin-amd64.tar.gz chadburn-darwin-amd64
+          tar -czf chadburn-darwin-arm64.tar.gz chadburn-darwin-arm64
+          
+          # Windows archives (zip)
+          zip chadburn-windows-amd64.zip chadburn-windows-amd64.exe
+          zip chadburn-windows-arm64.zip chadburn-windows-arm64.exe
+          
+          cd ..
 
-      # Step 11: Attach Built Binary to Release
-      - name: Attach Go Binary to GitHub Release
-        uses: wangyoucao577/go-release-action@v1.32
+      # Step 11: Generate checksums for all archives
+      - name: Generate checksums
+        run: |
+          cd ./dist
+          sha256sum *.tar.gz *.zip > checksums.txt
+          cd ..
+
+      # Step 12: Upload binaries as artifacts
+      - name: Upload binaries as artifacts
+        uses: actions/upload-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: linux
-          goarch: amd64
-          binary_name: "chadburn"
-          asset_name: "chadburn-linux-amd64"
-          extra_files: LICENSE README.md
+          name: chadburn-binaries
+          path: |
+            ./dist/*.tar.gz
+            ./dist/*.zip
+            ./dist/checksums.txt
+
+      # Step 13: Attach binaries to GitHub Release
+      - name: Attach binaries to GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./dist/*.tar.gz
+            ./dist/*.zip
+            ./dist/checksums.txt
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs-svelte/src/routes/changelog/+page.svelte
+++ b/docs-svelte/src/routes/changelog/+page.svelte
@@ -261,25 +261,138 @@
                             <!-- Assets -->
                             {#if release.assets && release.assets.length > 0}
                                 <div class="mt-8 pt-5 border-t border-gray-100">
-                                    <h3 class="text-sm font-semibold text-gray-900 mb-3 flex items-center">
-                                        <svg class="w-3.5 h-3.5 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <h3 class="text-base font-semibold text-gray-900 mb-4 flex items-center">
+                                        <svg class="w-4 h-4 mr-2 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
                                         </svg>
                                         Downloads ({release.assets.length})
                                     </h3>
-                                    <div class="flex flex-wrap gap-2">
-                                        {#each release.assets as asset}
-                                            <a href={asset.browser_download_url} 
-                                               class="text-xs px-3 py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors flex items-center gap-1"
-                                               download>
-                                                <svg class="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
-                                                </svg>
-                                                <span class="text-gray-700">{asset.name}</span>
-                                                <span class="text-gray-500 text-xs">({Math.round(asset.size / 1024)} KB)</span>
-                                            </a>
-                                        {/each}
-                                    </div>
+                                    
+                                    <!-- Group assets by platform -->
+                                    {#if release.assets.some(asset => asset.name.includes('.tar.gz') || asset.name.includes('.zip'))}
+                                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+                                            <!-- Linux Downloads -->
+                                            <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
+                                                <div class="flex items-center mb-3">
+                                                    <svg class="w-5 h-5 mr-2 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                                    </svg>
+                                                    <h4 class="font-medium text-gray-900">Linux</h4>
+                                                </div>
+                                                <div class="space-y-2">
+                                                    {#each release.assets.filter(asset => asset.name.includes('linux')) as asset}
+                                                        <a href={asset.browser_download_url} 
+                                                           class="flex items-center justify-between p-3 bg-white rounded border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition-colors group"
+                                                           download>
+                                                            <div class="flex items-center">
+                                                                <svg class="w-4 h-4 text-blue-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+                                                                </svg>
+                                                                <div>
+                                                                    <div class="text-sm font-medium text-gray-900">{asset.name.replace('chadburn-', '').replace('.tar.gz', '')}</div>
+                                                                    <div class="text-xs text-gray-500">{(asset.size / (1024 * 1024)).toFixed(2)} MB</div>
+                                                                </div>
+                                                            </div>
+                                                            <span class="text-xs bg-blue-100 text-blue-800 py-1 px-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity">Download</span>
+                                                        </a>
+                                                    {/each}
+                                                </div>
+                                            </div>
+                                            
+                                            <!-- macOS Downloads -->
+                                            <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
+                                                <div class="flex items-center mb-3">
+                                                    <svg class="w-5 h-5 mr-2 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                                    </svg>
+                                                    <h4 class="font-medium text-gray-900">macOS</h4>
+                                                </div>
+                                                <div class="space-y-2">
+                                                    {#each release.assets.filter(asset => asset.name.includes('darwin')) as asset}
+                                                        <a href={asset.browser_download_url} 
+                                                           class="flex items-center justify-between p-3 bg-white rounded border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition-colors group"
+                                                           download>
+                                                            <div class="flex items-center">
+                                                                <svg class="w-4 h-4 text-blue-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+                                                                </svg>
+                                                                <div>
+                                                                    <div class="text-sm font-medium text-gray-900">{asset.name.replace('chadburn-', '').replace('.tar.gz', '')}</div>
+                                                                    <div class="text-xs text-gray-500">{(asset.size / (1024 * 1024)).toFixed(2)} MB</div>
+                                                                </div>
+                                                            </div>
+                                                            <span class="text-xs bg-blue-100 text-blue-800 py-1 px-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity">Download</span>
+                                                        </a>
+                                                    {/each}
+                                                </div>
+                                            </div>
+                                            
+                                            <!-- Windows Downloads -->
+                                            <div class="bg-gray-50 p-4 rounded-lg border border-gray-200">
+                                                <div class="flex items-center mb-3">
+                                                    <svg class="w-5 h-5 mr-2 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                                    </svg>
+                                                    <h4 class="font-medium text-gray-900">Windows</h4>
+                                                </div>
+                                                <div class="space-y-2">
+                                                    {#each release.assets.filter(asset => asset.name.includes('windows')) as asset}
+                                                        <a href={asset.browser_download_url} 
+                                                           class="flex items-center justify-between p-3 bg-white rounded border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition-colors group"
+                                                           download>
+                                                            <div class="flex items-center">
+                                                                <svg class="w-4 h-4 text-blue-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+                                                                </svg>
+                                                                <div>
+                                                                    <div class="text-sm font-medium text-gray-900">{asset.name.replace('chadburn-', '').replace('.zip', '')}</div>
+                                                                    <div class="text-xs text-gray-500">{(asset.size / (1024 * 1024)).toFixed(2)} MB</div>
+                                                                </div>
+                                                            </div>
+                                                            <span class="text-xs bg-blue-100 text-blue-800 py-1 px-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity">Download</span>
+                                                        </a>
+                                                    {/each}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <!-- Checksums -->
+                                        {#if release.assets.some(asset => asset.name.includes('checksums.txt'))}
+                                            <div class="mt-4">
+                                                <div class="flex items-center mb-2">
+                                                    <svg class="w-4 h-4 mr-2 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                                                    </svg>
+                                                    <h4 class="text-sm font-medium text-gray-900">Checksums</h4>
+                                                </div>
+                                                {#each release.assets.filter(asset => asset.name.includes('checksums.txt')) as asset}
+                                                    <a href={asset.browser_download_url} 
+                                                       class="text-sm text-blue-600 hover:underline flex items-center"
+                                                       download>
+                                                        <svg class="w-3.5 h-3.5 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+                                                        </svg>
+                                                        Download SHA256 checksums
+                                                    </a>
+                                                {/each}
+                                            </div>
+                                        {/if}
+                                    {:else}
+                                        <!-- Display other assets if no binaries are found -->
+                                        <div class="flex flex-wrap gap-2">
+                                            {#each release.assets as asset}
+                                                <a href={asset.browser_download_url} 
+                                                   class="text-xs px-3 py-2 bg-gray-100 rounded hover:bg-gray-200 transition-colors flex items-center gap-1"
+                                                   download>
+                                                    <svg class="w-3 h-3 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+                                                    </svg>
+                                                    <span class="text-gray-700">{asset.name}</span>
+                                                    <span class="text-gray-500 text-xs">({Math.round(asset.size / 1024)} KB)</span>
+                                                </a>
+                                            {/each}
+                                        </div>
+                                    {/if}
                                 </div>
                             {:else}
                                 <div class="mt-8 pt-5 border-t border-gray-100">


### PR DESCRIPTION
## Changes Made\n- Enhanced GitHub Actions workflow to build binaries for multiple platforms (Linux, macOS, Windows)\n- Added support for multiple architectures (amd64, arm64, armv7)\n- Improved the Changelog page to display downloadable assets organized by platform\n- Added checksums for binary verification\n- Enhanced the visual presentation of downloadable assets\n\n## Features\n- Users can now download pre-built binaries for their specific platform\n- Assets are organized by operating system for easier navigation\n- File sizes are displayed for better user experience\n- SHA256 checksums are provided for security verification\n\nThis PR adds comprehensive binary distribution support, making it easier for users to download and use Chadburn on their preferred platform without having to build from source.